### PR TITLE
feat: import syntax with dynamic and var type remotes

### DIFF
--- a/apps/about/module-federation.config.js
+++ b/apps/about/module-federation.config.js
@@ -1,7 +1,11 @@
+const { dependencies } = require('../../package.json');
+
 module.exports = {
   name: 'about',
-  library: { type: 'var', name: 'about' },
   exposes: {
     './Module': './src/remote-entry.ts',
   },
+  filename: 'remoteEntry.js',
+  library: { type: 'var', name: 'about' },
+  shared: dependencies,
 };

--- a/apps/about/module-federation.config.js
+++ b/apps/about/module-federation.config.js
@@ -1,11 +1,7 @@
-const { dependencies } = require('../../package.json');
-
 module.exports = {
   name: 'about',
   exposes: {
     './Module': './src/remote-entry.ts',
   },
-  filename: 'remoteEntry.js',
   library: { type: 'var', name: 'about' },
-  shared: dependencies,
 };

--- a/apps/about/webpack.config.js
+++ b/apps/about/webpack.config.js
@@ -1,26 +1,16 @@
 const { composePlugins, withNx } = require('@nrwl/webpack');
 const { withReact } = require('@nrwl/react');
-const { withModuleFederation } = require('@nrwl/react/module-federation');
+const { ModuleFederationPlugin } = require('webpack').container;
 
 const baseConfig = require('./module-federation.config');
 
-const config = {
-  ...baseConfig,
-};
-
 // Nx plugins for webpack to build config object from Nx options and context.
-module.exports = composePlugins(
-  withNx(),
-  withReact(),
-  withModuleFederation(config),
-  (config) => {
-    return {
-      ...config,
-      experiments: { outputModule: false },
-      output: {
-        ...config.output,
-        scriptType: 'text/javascript',
-      },
-    };
-  }
-);
+module.exports = composePlugins(withNx(), withReact(), (config) => {
+  config.plugins.push(new ModuleFederationPlugin(baseConfig));
+  config.experiments.outputModule = false;
+  config.output.scriptType = 'text/javascript';
+  config.output.uniqueName = 'about';
+  config.output.publicPath = 'auto';
+  config.optimization = { runtimeChunk: false };
+  return config;
+});

--- a/apps/about/webpack.config.js
+++ b/apps/about/webpack.config.js
@@ -1,16 +1,22 @@
 const { composePlugins, withNx } = require('@nrwl/webpack');
 const { withReact } = require('@nrwl/react');
-const { ModuleFederationPlugin } = require('webpack').container;
 
 const baseConfig = require('./module-federation.config');
+const { withModuleFederation } = require('@nrwl/react/module-federation');
 
 // Nx plugins for webpack to build config object from Nx options and context.
-module.exports = composePlugins(withNx(), withReact(), (config) => {
-  config.plugins.push(new ModuleFederationPlugin(baseConfig));
-  config.experiments.outputModule = false;
-  config.output.scriptType = 'text/javascript';
-  config.output.uniqueName = 'about';
-  config.output.publicPath = 'auto';
-  config.optimization = { runtimeChunk: false };
-  return config;
-});
+module.exports = composePlugins(
+  withNx(),
+  withReact(),
+  withModuleFederation(baseConfig),
+  (config) => {
+    return {
+      ...config,
+      experiments: { outputModule: false },
+      output: {
+        ...config.output,
+        scriptType: 'text/javascript',
+      },
+    };
+  }
+);

--- a/apps/cart/module-federation.config.js
+++ b/apps/cart/module-federation.config.js
@@ -1,7 +1,11 @@
+const { dependencies } = require('../../package.json');
+
 module.exports = {
   name: 'cart',
-  library: { type: 'var', name: 'cart' },
   exposes: {
     './Module': './src/remote-entry.ts',
   },
+  filename: 'remoteEntry.js',
+  library: { type: 'var', name: 'cart' },
+  shared: dependencies,
 };

--- a/apps/cart/module-federation.config.js
+++ b/apps/cart/module-federation.config.js
@@ -1,11 +1,7 @@
-const { dependencies } = require('../../package.json');
-
 module.exports = {
   name: 'cart',
   exposes: {
     './Module': './src/remote-entry.ts',
   },
-  filename: 'remoteEntry.js',
   library: { type: 'var', name: 'cart' },
-  shared: dependencies,
 };

--- a/apps/cart/webpack.config.js
+++ b/apps/cart/webpack.config.js
@@ -1,16 +1,22 @@
 const { composePlugins, withNx } = require('@nrwl/webpack');
 const { withReact } = require('@nrwl/react');
-const { ModuleFederationPlugin } = require('webpack').container;
+const { withModuleFederation } = require('@nrwl/react/module-federation');
 
 const baseConfig = require('./module-federation.config');
 
 // Nx plugins for webpack to build config object from Nx options and context.
-module.exports = composePlugins(withNx(), withReact(), (config) => {
-  config.plugins.push(new ModuleFederationPlugin(baseConfig));
-  config.experiments.outputModule = false;
-  config.output.scriptType = 'text/javascript';
-  config.output.uniqueName = 'cart';
-  config.output.publicPath = 'auto';
-  config.optimization = { runtimeChunk: false };
-  return config;
-});
+module.exports = composePlugins(
+  withNx(),
+  withReact(),
+  withModuleFederation(baseConfig),
+  (config) => {
+    return {
+      ...config,
+      experiments: { outputModule: false },
+      output: {
+        ...config.output,
+        scriptType: 'text/javascript',
+      },
+    };
+  }
+);

--- a/apps/cart/webpack.config.js
+++ b/apps/cart/webpack.config.js
@@ -1,26 +1,16 @@
 const { composePlugins, withNx } = require('@nrwl/webpack');
 const { withReact } = require('@nrwl/react');
-const { withModuleFederation } = require('@nrwl/react/module-federation');
+const { ModuleFederationPlugin } = require('webpack').container;
 
 const baseConfig = require('./module-federation.config');
 
-const config = {
-  ...baseConfig,
-};
-
 // Nx plugins for webpack to build config object from Nx options and context.
-module.exports = composePlugins(
-  withNx(),
-  withReact(),
-  withModuleFederation(config),
-  (config) => {
-    return {
-      ...config,
-      experiments: { outputModule: false },
-      output: {
-        ...config.output,
-        scriptType: 'text/javascript',
-      },
-    };
-  }
-);
+module.exports = composePlugins(withNx(), withReact(), (config) => {
+  config.plugins.push(new ModuleFederationPlugin(baseConfig));
+  config.experiments.outputModule = false;
+  config.output.scriptType = 'text/javascript';
+  config.output.uniqueName = 'cart';
+  config.output.publicPath = 'auto';
+  config.optimization = { runtimeChunk: false };
+  return config;
+});

--- a/apps/host/module-federation.config.js
+++ b/apps/host/module-federation.config.js
@@ -1,5 +1,4 @@
 module.exports = {
   name: 'host',
-  library: { type: 'var', name: 'host' },
   remotes: ['shop', 'cart', 'about'],
 };

--- a/apps/host/src/app/app.tsx
+++ b/apps/host/src/app/app.tsx
@@ -2,39 +2,37 @@ import * as React from 'react';
 
 import NxWelcome from './nx-welcome';
 
-import { importRemote } from '@module-federation/utilities';
+// import { importRemote } from '@module-federation/utilities';
 
 import { Link, Route, Routes } from 'react-router-dom';
 
-// const Shop = React.lazy(() => import('shop/Module'));
+import Shop from 'shop/Module';
+import Cart from 'cart/Module';
+import About from 'about/Module';
 
-// const Cart = React.lazy(() => import('cart/Module'));
+// const About = React.lazy(() =>
+//   importRemote({
+//     scope: 'about',
+//     module: './Module',
+//     url: `http://localhost:4203`,
+//   })
+// );
 
-// const About = React.lazy(() => import('about/Module'));
+// const Shop = React.lazy(() =>
+//   importRemote({
+//     scope: 'shop',
+//     module: './Module',
+//     url: `http://localhost:4201`,
+//   })
+// );
 
-const About = React.lazy(() =>
-  importRemote({
-    scope: 'about',
-    module: './Module',
-    url: `http://localhost:4203`,
-  })
-);
-
-const Shop = React.lazy(() =>
-  importRemote({
-    scope: 'shop',
-    module: './Module',
-    url: `http://localhost:4201`,
-  })
-);
-
-const Cart = React.lazy(() =>
-  importRemote({
-    scope: 'cart',
-    module: './Module',
-    url: `http://localhost:4202`,
-  })
-);
+// const Cart = React.lazy(() =>
+//   importRemote({
+//     scope: 'cart',
+//     module: './Module',
+//     url: `http://localhost:4202`,
+//   })
+// );
 
 export function App() {
   return (

--- a/apps/host/webpack.config.js
+++ b/apps/host/webpack.config.js
@@ -1,7 +1,6 @@
 const { composePlugins, withNx } = require('@nrwl/webpack');
 const { withReact } = require('@nrwl/react');
 const { ModuleFederationPlugin } = require('webpack').container;
-const ExternalTemplateRemotesPlugin = require('external-remotes-plugin');
 const packageJSON = require('../../package.json');
 
 // Nx plugins for webpack to build config object from Nx options and context.

--- a/apps/host/webpack.config.js
+++ b/apps/host/webpack.config.js
@@ -1,26 +1,24 @@
 const { composePlugins, withNx } = require('@nrwl/webpack');
 const { withReact } = require('@nrwl/react');
-const { withModuleFederation } = require('@nrwl/react/module-federation');
-
-const baseConfig = require('./module-federation.config');
-
-const config = {
-  ...baseConfig,
-};
+const { ModuleFederationPlugin } = require('webpack').container;
+const ExternalTemplateRemotesPlugin = require('external-remotes-plugin');
+const packageJSON = require('../../package.json');
 
 // Nx plugins for webpack to build config object from Nx options and context.
-module.exports = composePlugins(
-  withNx(),
-  withReact(),
-  withModuleFederation(config),
-  (config) => {
-    return {
-      ...config,
-      experiments: { outputModule: false },
-      output: {
-        ...config.output,
-        scriptType: 'text/javascript',
+module.exports = composePlugins(withNx(), withReact(), (config) => {
+  config.experiments.outputModule = false;
+  config.output.scriptType = 'text/javascript';
+  config.output.publicPath = 'auto';
+  config.plugins.push(
+    new ModuleFederationPlugin({
+      name: 'host',
+      remotes: {
+        cart: 'cart@http://localhost:4202/remoteEntry.js',
+        about: 'about@http://localhost:4203/remoteEntry.js',
+        shop: 'shop@http://localhost:4201/remoteEntry.js',
       },
-    };
-  }
-);
+      shared: packageJSON.dependencies,
+    })
+  );
+  return config;
+});

--- a/apps/shop/module-federation.config.js
+++ b/apps/shop/module-federation.config.js
@@ -1,11 +1,7 @@
-const { dependencies } = require('../../package.json');
-
 module.exports = {
   name: 'shop',
   exposes: {
     './Module': './src/remote-entry.ts',
   },
-  filename: 'remoteEntry.js',
   library: { type: 'var', name: 'shop' },
-  shared: dependencies,
 };

--- a/apps/shop/module-federation.config.js
+++ b/apps/shop/module-federation.config.js
@@ -1,7 +1,11 @@
+const { dependencies } = require('../../package.json');
+
 module.exports = {
   name: 'shop',
-  library: { type: 'var', name: 'shop' },
   exposes: {
     './Module': './src/remote-entry.ts',
   },
+  filename: 'remoteEntry.js',
+  library: { type: 'var', name: 'shop' },
+  shared: dependencies,
 };

--- a/apps/shop/webpack.config.js
+++ b/apps/shop/webpack.config.js
@@ -1,16 +1,22 @@
 const { composePlugins, withNx } = require('@nrwl/webpack');
 const { withReact } = require('@nrwl/react');
-const { ModuleFederationPlugin } = require('webpack').container;
+const { withModuleFederation } = require('@nrwl/react/module-federation');
 
 const baseConfig = require('./module-federation.config');
 
 // Nx plugins for webpack to build config object from Nx options and context.
-module.exports = composePlugins(withNx(), withReact(), (config) => {
-  config.plugins.push(new ModuleFederationPlugin(baseConfig));
-  config.experiments.outputModule = false;
-  config.output.scriptType = 'text/javascript';
-  config.output.uniqueName = 'shop';
-  config.output.publicPath = 'auto';
-  config.optimization = { runtimeChunk: false };
-  return config;
-});
+module.exports = composePlugins(
+  withNx(),
+  withReact(),
+  withModuleFederation(baseConfig),
+  (config) => {
+    return {
+      ...config,
+      experiments: { outputModule: false },
+      output: {
+        ...config.output,
+        scriptType: 'text/javascript',
+      },
+    };
+  }
+);

--- a/apps/shop/webpack.config.js
+++ b/apps/shop/webpack.config.js
@@ -1,26 +1,16 @@
 const { composePlugins, withNx } = require('@nrwl/webpack');
 const { withReact } = require('@nrwl/react');
-const { withModuleFederation } = require('@nrwl/react/module-federation');
+const { ModuleFederationPlugin } = require('webpack').container;
 
 const baseConfig = require('./module-federation.config');
 
-const config = {
-  ...baseConfig,
-};
-
 // Nx plugins for webpack to build config object from Nx options and context.
-module.exports = composePlugins(
-  withNx(),
-  withReact(),
-  withModuleFederation(config),
-  (config) => {
-    return {
-      ...config,
-      experiments: { outputModule: false },
-      output: {
-        ...config.output,
-        scriptType: 'text/javascript',
-      },
-    };
-  }
-);
+module.exports = composePlugins(withNx(), withReact(), (config) => {
+  config.plugins.push(new ModuleFederationPlugin(baseConfig));
+  config.experiments.outputModule = false;
+  config.output.scriptType = 'text/javascript';
+  config.output.uniqueName = 'shop';
+  config.output.publicPath = 'auto';
+  config.optimization = { runtimeChunk: false };
+  return config;
+});


### PR DESCRIPTION
### PR Summary

Adds support for `import About from 'about/Module'` syntax of loading remotes via Module Federation with support for `var` type remote libraries.

### Recording of the implemented changes

https://github.com/infoxicator/nx-import-module-bug/assets/35926159/4a384b26-cc58-43b7-88b4-af523b9b5626

