### PR TITLE
fix(host): add correct remoteType

### DIFF
--- a/apps/host/src/app/app.tsx
+++ b/apps/host/src/app/app.tsx
@@ -10,15 +10,16 @@ import { Link, Route, Routes } from 'react-router-dom';
 
 // const Cart = React.lazy(() => import('cart/Module'));
 
-// const About = React.lazy(() => import('about/Module'));
+// Supports both syntaxes, direct import and also importRemote (dynamic remotes)
+const About = React.lazy(() => import('about/Module'));
 
-const About = React.lazy(() =>
-  importRemote({
-    scope: 'about',
-    module: './Module',
-    url: `http://localhost:4203`,
-  })
-);
+// const About = React.lazy(() =>
+//   importRemote({
+//     scope: 'about',
+//     module: './Module',
+//     url: `http://localhost:4203`,
+//   })
+// );
 
 const Shop = React.lazy(() =>
   importRemote({

--- a/apps/host/webpack.config.js
+++ b/apps/host/webpack.config.js
@@ -1,7 +1,7 @@
 const { composePlugins, withNx } = require('@nrwl/webpack');
 const { withReact } = require('@nrwl/react');
 const { withModuleFederation } = require('@nrwl/react/module-federation');
-
+const { ModuleFederationPlugin } = require('webpack').container;
 const baseConfig = require('./module-federation.config');
 
 const config = {
@@ -14,6 +14,33 @@ module.exports = composePlugins(
   withReact(),
   withModuleFederation(config),
   (config) => {
+    for (const [index, plugin] of config.plugins.entries()) {
+      if (plugin.constructor.name === 'ModuleFederationPlugin') {
+        const processedRemotes = {};
+        for (let remote in plugin._options.remotes) {
+          /* Replace hyphens with underscores in remote name and
+           * prepend remote name with remote name and '@' symbol as required by ModuleFederationPlugin var remoteType
+           * i.e remote@http://localhost:4201/remoteEntry.js
+           */
+          processedRemotes[remote] = `${remote.replace(/-/g, '_')}@${
+            plugin._options.remotes[remote]
+          }`;
+        }
+        config.plugins[index] = new ModuleFederationPlugin({
+          ...plugin._options,
+          remotes: processedRemotes,
+          /**
+           * default: library.type if 'in' RemoteType or 'script'
+           * remoteType needs to be 'script' (defaults to if not set or when library.type is not set)
+           * remoteType might (if not set) default to library.type, so watch out
+           * remoteType need to be the same as remote container library.type, otherwise throws "Uncaught SyntaxError: expected expression, got '!=='"
+           * note: it can happen that static import throws "Uncaught TypeError: __webpack_modules__[moduleId] is not a function" error
+           *  this can be resolved if we dynamically load the using module or one of its parents.
+           */
+          remoteType: 'script',
+        });
+      }
+    }
     return {
       ...config,
       experiments: { outputModule: false },


### PR DESCRIPTION
This PR completes the required changes for the NX module federation plugin to work in remoteType `var` mode (disable ESM)

Supports for any import syntax:

`import remote from 'remote/Module'`

`[importRemote](https://www.npmjs.com/package/@module-federation/utilities)` (Dynamic Remotes)

and [`promise based dynamic remotes`](https://webpack.js.org/concepts/module-federation/#promise-based-dynamic-remotes).

Summary of Changes:

- Host `remoteType: 'script',` needs to be set to `script`. Seems like a configuration error in NX that is overriding this value
- Remotes object needs to use the. `remote@http://localhost:4201/remoteEntry.js` syntax when using `remoteType` `var`
- Remotes with a hyphen (`-`) in the name are not allowed when passed to the above syntax